### PR TITLE
Add errata for size of test deposit and segwit issue

### DIFF
--- a/errata.html
+++ b/errata.html
@@ -20,12 +20,19 @@ section_id: errata
 		<br />
 		<span style="font-size: 0.8em;"><em>Technical note:  Unlike the actual protocol document, these errata are not secured with signed checksums.</span></em>
 
+    <h3>v0.92 Beta errata</h3>
+
+    <ul>
+      <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) might be too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57. Fees have since declined, but the user is advised to check the current fee rate before making the test deposit.</li>
+    </ul>
+
     <h3>v0.91 Beta errata</h3>
 
     <ul>
       <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) might be too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57. Fees have since declined, but the user is advised to check the current fee rate before making the test deposit.</li>
-      <li>Funding your Glacier cold-storage address from a segwit-enabled wallet (e.g. Electrum 3) may result in unspendable funds. (Your funds are safe, and a future Glacier release will enable spending!) To avoid this problem:
+      <li>Funding your Glacier cold-storage address from a segwit-enabled wallet (e.g. Electrum 3) may result in unspendable funds. (Your funds are safe; Glacier v0.92 Beta fixes this and enables your funds to be spent.) To avoid this problem:
 	<ul>
+	  <li>Create or recreate your App USBs using Glacier v0.92 Beta; or</li>
 	  <li>Fund your Glacier address using a wallet that is not Segwit compatible; or</li>
 	  <li>Send 100% of your wallet's funds to your Glacier address in a single transaction (so that no change output is created)</li>
 	</ul>

--- a/errata.html
+++ b/errata.html
@@ -22,7 +22,9 @@ section_id: errata
 
     <h3>v0.91 Beta errata</h3>
 
-    <p>No errata identified.</p>
+    <ul>
+      <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) is far too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57.</li>
+    </ul>
     
 		  
 	  <h3>v0.9 Beta errata</h3>

--- a/errata.html
+++ b/errata.html
@@ -23,6 +23,7 @@ section_id: errata
     <h3>v0.92 Beta errata</h3>
 
     <ul>
+      <li>The cover page of the PDF is still titled version 0.91.</li>
       <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) might be too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57. Fees have since declined, but the user is advised to check the current fee rate before making the test deposit.</li>
     </ul>
 

--- a/errata.html
+++ b/errata.html
@@ -23,7 +23,7 @@ section_id: errata
     <h3>v0.91 Beta errata</h3>
 
     <ul>
-      <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) is far too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57.</li>
+      <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) might be too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57. Fees have since declined, but the user is advised to check the current fee rate before making the test deposit.</li>
       <li>Funding your Glacier cold-storage address from a segwit-enabled wallet (e.g. Electrum 3) may result in unspendable funds. (Your funds are safe, and a future Glacier release will enable spending!) To avoid this problem:
 	<ul>
 	  <li>Fund your Glacier address using a wallet that is not Segwit compatible; or</li>

--- a/errata.html
+++ b/errata.html
@@ -24,6 +24,12 @@ section_id: errata
 
     <ul>
       <li>Deposit Protocol, Section III, step 2.a: The recommended size of the test deposit ($6) is far too small for today's transaction fees. We recommend a deposit sufficient to fund 1000 bytes of transactions; as of January 17, 2018, with a fee rate of 510 sat/B and $11185 USD/BTC this is a deposit of approximately $57.</li>
+      <li>Funding your Glacier cold-storage address from a segwit-enabled wallet (e.g. Electrum 3) may result in unspendable funds. (Your funds are safe, and a future Glacier release will enable spending!) To avoid this problem:
+	<ul>
+	  <li>Fund your Glacier address using a wallet that is not Segwit compatible; or</li>
+	  <li>Send 100% of your wallet's funds to your Glacier address in a single transaction (so that no change output is created)</li>
+	</ul>
+      </li>
     </ul>
     
 		  

--- a/releases.html
+++ b/releases.html
@@ -41,7 +41,23 @@ section_id: releases
 	  <p style="font-size: 0.8em;">If you are referencing release notes as directed by Glacier protocol itself, you should refer to the canonical notes in the protocol document itself rather than the notes here. The appropriate steps are listed in the protocol.</em></p>
 
     <p><strong>Version 0.92: Mar 5, 2018</strong></p>
-    <p>v0.92 supports Bitcoin Core 0.16, fixes crash when unspent xact has native segwit outputs, and forces re-entry of fee rate when user declines fee confirmation prompt.</p>
+    <strong>Upgrade Guidance</strong>
+    <p>v0.92 includes a fix for some withdrawal errors encountered in v0.91.  If you encounter errors withdrawing in v0.91, you should upgrade to v0.92.  You'll need to recreate your Quarantined App USBs with v0.92.</p>
+
+    <p>v0.92 includes a fix for compatibility with Bitcoin Core v0.16.0.  If you are creating new App USBs, you should use v0.92.</p>
+
+    <p>v0.92 has no security improvements.  Funds stored with earlier Deposit Protocols are perfectly secure.</p>
+
+    <p>Note that the PDF document did not change from v0.91, and is still titled v0.91 on the cover page.</p>
+
+    <strong>Detailed Changes</strong>
+    <ul>
+      <li>v0.92 adds support for Bitcoin Core 0.16.  Any new App USBs created on or after March 5, 2018 (when the <a href="https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin">Ubuntu Bitcoin PPA</a> was updated with v0.16.0) using an older version of Glacier will fail with GlacierScript errors during the Withdrawal Protocol and Deposit Protocol.  Any App USBs created before that date will still work and are safe to continue using (excepting other errata).</li>
+
+      <li>Fixes crash when unspent xact has native segwit outputs. If your Glacier wallet was funded using a transaction containing native Segwit outputs (such as the change output from an Electrum 3 Segwit wallet), previous versions of GlacierScript would crash when trying to withdraw.</li>
+
+      <li>Forces re-entry of fee rate when user declines fee confirmation prompt. Previous versions of GlacierScript erroneously recalculated using the same fee rate instead of prompting the user for a corrected rate.</li>
+    </ul>
 
     <p><strong>Version 0.91: July 27, 2017</strong></p>
 


### PR DESCRIPTION
Updating web site errata to recommend larger test deposit as discussed in [issue #13](https://github.com/GlacierProtocol/GlacierProtocol/issues/13)