### PR TITLE
Add warning about Bitcoin Core v0.16.0 breaking Glacier

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -109,7 +109,7 @@
 
           <p class='glacier-warning-headline'>
             New Glacier setups temporarily broken
-            <br><span class='glacier-warning-dateline'>February 26, 2018</span>
+            <br><span class='glacier-warning-dateline'>March 5, 2018</span>
           </p>
 
           <p>The recent release of Bitcoin Core v0.16.0 has some API changes incompatible with Glacier v0.91. A new release of Glacier is coming soon. Your funds are safe.</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -108,6 +108,20 @@
         <section>
 
           <p class='glacier-warning-headline'>
+            New Glacier setups temporarily broken
+            <br><span class='glacier-warning-dateline'>February 26, 2018</span>
+          </p>
+
+          <p>The recent release of Bitcoin Core v0.16.0 has some API changes incompatible with Glacier v0.91. A new release of Glacier is coming soon. Your funds are safe.</p>
+	  <p>Any APP USBs created with Glacier v0.91 and Bitcoin Core v0.16.0 will see errors from glacierscript.py when performing either the Deposit Protocol or the Withdrawal Protocol.</p>
+	  <p>You may safely continue to use APP USBs created earlier.</p>
+        </section>
+      </div>
+
+      <div class='contain-to-grid glacier-warning'>
+        <section>
+
+          <p class='glacier-warning-headline'>
             Community bounty for BCH withdrawal tool
             <br><span class='glacier-warning-dateline'>September 30, 2017</span>
           </p>


### PR DESCRIPTION
@diogomonica if you can't get a new Glacier release out ASAP, please merge this PR.

Once Bitcoin Core v0.16.0 makes it onto the Ubuntu PPA, Glacier will be broken, as documented in [#16](https://github.com/GlacierProtocol/GlacierProtocol/issues/16) and [#17](https://github.com/GlacierProtocol/GlacierProtocol/issues/17).

I would hate for a new user to spend hours following the Setup Protocol only to find out that the APP USB keys he made are broken. That would make for a very bad first impression, and likely a last impression.

Of course we will revert this change once a new release is out with fixes for these issues.
