### PR TITLE
fix typo for macos command when creating boot usb

### DIFF
--- a/_docs/setup/create-boot-usb.md
+++ b/_docs/setup/create-boot-usb.md
@@ -161,7 +161,7 @@ copy there.
                 ```
             6.  
                 ```
-                $ sudo cmp -n `stat -f '%z' ubuntu-16.04.1-desktop-amd64.img.dmg ubuntu-16.04.1-desktop-amd64.img.dmg` USB-device-identifier-here
+                $ sudo cmp -n `stat -f '%z' ubuntu-16.04.1-desktop-amd64.img.dmg` ubuntu-16.04.1-desktop-amd64.img.dmg USB-device-identifier-here
                 ```
             7. Wait a few minutes for the verification process to complete.
             8. If all goes well, the command will output no data, returning to


### PR DESCRIPTION
I found an typo with the command `cmp` on mac.
We want to get the length of the install file to give to the `-n` option and then compare the 2 files.
There was a misplaced backquote.