### PR TITLE
Fix link to Ubuntu 16.04.1 fingerprint

### DIFF
--- a/_docs/setup/create-boot-usb.md
+++ b/_docs/setup/create-boot-usb.md
@@ -80,7 +80,7 @@ copy there.
         security analysis, see the design document.
 
         You can verify this is the official Ubuntu fingerprint
-        [here](http://releases.ubuntu.com/16.04/SHA256SUMS),
+        [here](http://releases.ubuntu.com/16.04.1/SHA256SUMS),
         or follow Ubuntu's full verification process using this guide.
 
 6. Create the SETUP 1 BOOT USB.


### PR DESCRIPTION
I cherry-picked this from @GraniteKeep's massive change in #17. This one is easy to review and should be merged ASAP.

However, I noticed the new link in this commit gets redirected. Should we use the redirected URL instead? http://old-releases.ubuntu.com/releases/16.04.1/SHA256SUMS